### PR TITLE
Fix download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ production systems.
 Get the source code:
 
 ```sh
-go get github.com/cloudflare/opaque-core
+git clone https://github.com/cloudflare/opaque-core
 ```
 
 ## Running tests


### PR DESCRIPTION
It's not possible to go get github.com/cloudflare/opaque-core because this is not a Go package.